### PR TITLE
Render prereading popup with rich formatting (HTML viewer)

### DIFF
--- a/crossbill.koplugin/modules/prereading_viewer.lua
+++ b/crossbill.koplugin/modules/prereading_viewer.lua
@@ -1,0 +1,229 @@
+--[[
+Prereading Viewer Module for Crossbill Sync
+
+A self-contained, scrollable dialog that renders prereading content (summary,
+key points, questions) as rich HTML — so inline markdown (bold, italics, code)
+shows up properly.
+
+It is built on ScrollHtmlWidget, which has been stable for years (it powers the
+dictionary popup), rather than TextViewer's markdown support, which only exists
+on KOReader master and is absent from released versions.
+
+The dialog structure mirrors the stable TextViewer: a TitleBar, a scrollable
+body and a single-button ButtonTable, composed inside
+FrameContainer/MovableContainer/WidgetContainer. It can be dismissed via the
+Close button, by tapping outside the frame, or with the Back key.
+
+Constructor options:
+  title  string  Chapter title shown in the title bar
+  html   string  Full body HTML to render
+]]
+
+local Blitbuffer = require("ffi/blitbuffer")
+local ButtonTable = require("ui/widget/buttontable")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local Device = require("device")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local MovableContainer = require("ui/widget/container/movablecontainer")
+local ScrollHtmlWidget = require("ui/widget/scrollhtmlwidget")
+local Size = require("ui/size")
+local TitleBar = require("ui/widget/titlebar")
+local UIManager = require("ui/uimanager")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local _ = require("gettext")
+local Screen = Device.screen
+
+-- Base font size for the HTML body (matches TextViewer's default text size).
+local FONT_SIZE = Screen:scaleBySize(20)
+
+-- CSS adapted from KOReader master's TextViewer HTML block, with extra rules
+-- for the headings and lists we generate, tuned for e-ink readability.
+local CSS = [[
+	@page {
+		margin: 0;
+	}
+	body {
+		margin: 0;
+		line-height: 1.3;
+	}
+	h2 {
+		font-size: 1.1em;
+		margin-top: 1em;
+		margin-bottom: 0.3em;
+	}
+	ul, ol {
+		margin: 0.3em 0;
+		padding-left: 1.5em;
+	}
+	li {
+		margin-bottom: 0.2em;
+	}
+]]
+
+local PrereadingViewer = InputContainer:extend({
+	title = nil,
+	html = nil,
+	width = nil,
+	height = nil,
+	close_callback = nil,
+	-- Sizing constants copied from the stable TextViewer.
+	text_padding = Size.padding.large,
+	text_margin = Size.margin.small,
+	button_padding = Size.padding.default,
+})
+
+function PrereadingViewer:init()
+	local screen_w = Screen:getWidth()
+	local screen_h = Screen:getHeight()
+
+	self.align = "center"
+	self.region = Geom:new({
+		w = screen_w,
+		h = screen_h,
+	})
+	self.width = self.width or screen_w - Screen:scaleBySize(30)
+	self.height = self.height or screen_h - Screen:scaleBySize(30)
+
+	if Device:hasKeys() then
+		self.key_events.Close = { { Device.input.group.Back } }
+	end
+
+	if Device:isTouchDevice() then
+		local range = Geom:new({
+			w = screen_w,
+			h = screen_h,
+		})
+		self.ges_events = {
+			TapClose = {
+				GestureRange:new({
+					ges = "tap",
+					range = range,
+				}),
+			},
+			MultiSwipe = {
+				GestureRange:new({
+					ges = "multiswipe",
+					range = range,
+				}),
+			},
+		}
+	end
+
+	self.titlebar = TitleBar:new({
+		width = self.width,
+		align = "left",
+		with_bottom_line = true,
+		title = self.title,
+		close_callback = function()
+			self:onClose()
+		end,
+		show_parent = self,
+	})
+
+	self.button_table = ButtonTable:new({
+		width = self.width - 2 * self.button_padding,
+		buttons = {
+			{
+				{
+					text = _("Close"),
+					callback = function()
+						self:onClose()
+					end,
+				},
+			},
+		},
+		zero_sep = true,
+		show_parent = self,
+	})
+
+	-- Body height = dialog height minus the title bar and button row, following
+	-- the stable TextViewer's math exactly.
+	local htmlw_height = self.height - self.titlebar:getHeight() - self.button_table:getSize().h
+	self.scroll_widget = ScrollHtmlWidget:new({
+		html_body = self.html,
+		css = CSS,
+		default_font_size = FONT_SIZE,
+		width = self.width - 2 * self.text_padding - 2 * self.text_margin,
+		height = htmlw_height - 2 * self.text_padding - 2 * self.text_margin,
+		dialog = self,
+	})
+	self.htmlw = FrameContainer:new({
+		padding = self.text_padding,
+		margin = self.text_margin,
+		bordersize = 0,
+		self.scroll_widget,
+	})
+
+	self.frame = FrameContainer:new({
+		radius = Size.radius.window,
+		padding = 0,
+		margin = 0,
+		background = Blitbuffer.COLOR_WHITE,
+		VerticalGroup:new({
+			self.titlebar,
+			CenterContainer:new({
+				dimen = Geom:new({
+					w = self.width,
+					h = self.htmlw:getSize().h,
+				}),
+				self.htmlw,
+			}),
+			CenterContainer:new({
+				dimen = Geom:new({
+					w = self.width,
+					h = self.button_table:getSize().h,
+				}),
+				self.button_table,
+			}),
+		}),
+	})
+	self.movable = MovableContainer:new({
+		anchor = self.anchor,
+		self.frame,
+	})
+	self[1] = WidgetContainer:new({
+		align = self.align,
+		dimen = self.region,
+		self.movable,
+	})
+end
+
+function PrereadingViewer:onCloseWidget()
+	UIManager:setDirty(nil, function()
+		return "partial", self.frame.dimen
+	end)
+end
+
+function PrereadingViewer:onShow()
+	UIManager:setDirty(self, function()
+		return "partial", self.frame.dimen
+	end)
+	return true
+end
+
+function PrereadingViewer:onTapClose(arg, ges_ev)
+	if ges_ev.pos:notIntersectWith(self.frame.dimen) then
+		self:onClose()
+	end
+	return true
+end
+
+function PrereadingViewer:onMultiSwipe(arg, ges_ev)
+	-- Any multiswipe closes, for consistency with other fullscreen widgets.
+	self:onClose()
+	return true
+end
+
+function PrereadingViewer:onClose()
+	UIManager:close(self)
+	if self.close_callback then
+		self.close_callback()
+	end
+	return true
+end
+
+return PrereadingViewer

--- a/crossbill.koplugin/modules/ui.lua
+++ b/crossbill.koplugin/modules/ui.lua
@@ -11,7 +11,19 @@ local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
 local TextViewer = require("ui/widget/textviewer")
+local logger = require("logger")
 local _ = require("gettext")
+
+-- The rich HTML viewer pulls in several KOReader widgets. On an exotic build
+-- where one of those requires is unavailable, we fall back to a plain-text
+-- TextViewer, so load it protectively and treat a failure as "not available".
+local ok_viewer, PrereadingViewer = pcall(function()
+	return require("modules/prereading_viewer")
+end)
+if not ok_viewer then
+	logger.warn("Crossbill: prereading HTML viewer unavailable: " .. tostring(PrereadingViewer))
+	PrereadingViewer = nil
+end
 
 local UI = {}
 
@@ -100,47 +112,79 @@ local function stripMarkdown(text)
 	return result
 end
 
---- Check whether this KOReader's TextViewer can render markdown as HTML
--- Newer TextViewers accept text_format = "md" and render via ScrollHtmlWidget;
--- older ones lack html_text_formats entirely and show plain text only.
--- @return boolean True if markdown rendering is available
-local function supportsMarkdown()
-	return type(TextViewer.html_text_formats) == "table" and TextViewer.html_text_formats.md == true
+--- Escape HTML-special characters so raw content can't break the markup
+-- Ampersand MUST be escaped first, otherwise the entities we introduce for
+-- < and > would themselves get double-escaped.
+-- @param text any The raw text (non-strings pass through tostring)
+-- @return string HTML-safe text
+local function escapeHtml(text)
+	local result = tostring(text)
+	result = result:gsub("&", "&amp;")
+	result = result:gsub("<", "&lt;")
+	result = result:gsub(">", "&gt;")
+	return result
 end
 
---- Build the popup body as markdown (rendered as HTML by newer TextViewers)
--- Summary, keypoints and questions are passed through verbatim so their own
--- inline markdown (bold, italics) renders properly.
+--- Convert a single line of inline markdown to HTML
+-- HTML-escapes first (so content is safe), then converts markdown markers to
+-- tags. Bold (**/__) is handled before italics (*) so the double markers are
+-- consumed first.
+-- @param text any The raw text (non-strings pass through tostring)
+-- @return string HTML with inline markup applied
+local function inlineMarkdownToHtml(text)
+	local result = escapeHtml(text)
+	result = result:gsub("%*%*(.-)%*%*", "<strong>%1</strong>")
+	result = result:gsub("__(.-)__", "<strong>%1</strong>")
+	result = result:gsub("%*(.-)%*", "<em>%1</em>")
+	result = result:gsub("`(.-)`", "<code>%1</code>")
+	return result
+end
+
+--- Build the popup body as HTML, with inline markdown rendered as tags
+-- Summary paragraphs (separated by blank lines) become <p> blocks; key points
+-- become a <ul>, questions an <ol>. All content flows through
+-- inlineMarkdownToHtml so bold/italics/code render properly.
 -- @param item table Prereading item with summary, keypoints, questions
--- @return string Markdown body
-local function buildPrereadingMarkdown(item)
-	local sections = {}
+-- @return string HTML body
+local function buildPrereadingHtml(item)
+	local parts = {}
 
 	if item.summary and item.summary ~= "" then
-		table.insert(sections, tostring(item.summary))
+		-- Split the summary on blank lines into separate <p> blocks. Appending
+		-- a trailing blank line lets the final paragraph match too.
+		for paragraph in (tostring(item.summary) .. "\n\n"):gmatch("(.-)\n%s*\n") do
+			local trimmed = paragraph:gsub("^%s+", ""):gsub("%s+$", "")
+			if trimmed ~= "" then
+				table.insert(parts, "<p>" .. inlineMarkdownToHtml(trimmed) .. "</p>")
+			end
+		end
 	end
 
 	if item.keypoints and #item.keypoints > 0 then
-		local lines = { "## " .. _("Key points") }
+		table.insert(parts, "<h2>" .. escapeHtml(_("Key points")) .. "</h2>")
+		local list = { "<ul>" }
 		for _idx, point in ipairs(item.keypoints) do
-			table.insert(lines, "- " .. tostring(point))
+			table.insert(list, "<li>" .. inlineMarkdownToHtml(point) .. "</li>")
 		end
-		table.insert(sections, table.concat(lines, "\n"))
+		table.insert(list, "</ul>")
+		table.insert(parts, table.concat(list))
 	end
 
 	if item.questions and #item.questions > 0 then
-		local lines = { "## " .. _("Questions to think about") }
-		for i, question in ipairs(item.questions) do
-			table.insert(lines, tostring(i) .. ". " .. tostring(question))
+		table.insert(parts, "<h2>" .. escapeHtml(_("Questions to think about")) .. "</h2>")
+		local list = { "<ol>" }
+		for _idx, question in ipairs(item.questions) do
+			table.insert(list, "<li>" .. inlineMarkdownToHtml(question) .. "</li>")
 		end
-		table.insert(sections, table.concat(lines, "\n"))
+		table.insert(list, "</ol>")
+		table.insert(parts, table.concat(list))
 	end
 
-	if #sections == 0 then
-		return _("No prereading content available for this chapter.")
+	if #parts == 0 then
+		return "<p>" .. escapeHtml(_("No prereading content available for this chapter.")) .. "</p>"
 	end
 
-	return table.concat(sections, "\n\n")
+	return table.concat(parts, "\n")
 end
 
 --- Build the popup body as plain text, with markdown markers stripped
@@ -178,22 +222,29 @@ local function buildPrereadingBody(item)
 end
 
 --- Show the prereading popup for a matched chapter item
--- Renders the body as markdown (bold, headings, lists) when this KOReader's
--- TextViewer supports it, falling back to plain text with markers stripped.
+-- Renders the body as rich HTML (bold, headings, lists) via our own
+-- ScrollHtmlWidget-based viewer. If that viewer is unavailable or fails to
+-- construct on some exotic build, falls back to a plain-text TextViewer with
+-- markdown markers stripped.
 -- @param item table Prereading item to display
 function UI.showPrereadingPopup(item)
-	if supportsMarkdown() then
-		UIManager:show(TextViewer:new({
-			title = buildPrereadingTitle(item),
-			text = buildPrereadingMarkdown(item),
-			text_format = "md",
-		}))
-	else
-		UIManager:show(TextViewer:new({
-			title = buildPrereadingTitle(item),
-			text = buildPrereadingBody(item),
-		}))
+	if PrereadingViewer then
+		local ok, err = pcall(function()
+			UIManager:show(PrereadingViewer:new({
+				title = buildPrereadingTitle(item),
+				html = buildPrereadingHtml(item),
+			}))
+		end)
+		if ok then
+			return
+		end
+		logger.warn("Crossbill: prereading HTML viewer failed, using plain text: " .. tostring(err))
 	end
+
+	UIManager:show(TextViewer:new({
+		title = buildPrereadingTitle(item),
+		text = buildPrereadingBody(item),
+	}))
 end
 
 --- Show a message when no prereading is cached and we are offline

--- a/crossbill.koplugin/modules/ui.lua
+++ b/crossbill.koplugin/modules/ui.lua
@@ -83,26 +83,53 @@ local function buildPrereadingTitle(item)
 	return chapter_name
 end
 
---- Build the body text for a prereading item
+--- Strip markdown inline markers from a text for plain-text display
+-- The server's prereading content contains markdown (e.g. **bold**), which
+-- older TextViewers render as literal asterisks. Order matters: bold before
+-- italics so ** is consumed first.
+-- @param text any The raw text (non-strings pass through tostring)
+-- @return string The text without markdown markers
+local function stripMarkdown(text)
+	local result = tostring(text)
+	result = result:gsub("%*%*(.-)%*%*", "%1")
+	result = result:gsub("__(.-)__", "%1")
+	result = result:gsub("%*(.-)%*", "%1")
+	result = result:gsub("`(.-)`", "%1")
+	-- Leading heading markers at the start of any line
+	result = result:gsub("^#+%s*", ""):gsub("\n#+%s*", "\n")
+	return result
+end
+
+--- Check whether this KOReader's TextViewer can render markdown as HTML
+-- Newer TextViewers accept text_format = "md" and render via ScrollHtmlWidget;
+-- older ones lack html_text_formats entirely and show plain text only.
+-- @return boolean True if markdown rendering is available
+local function supportsMarkdown()
+	return type(TextViewer.html_text_formats) == "table" and TextViewer.html_text_formats.md == true
+end
+
+--- Build the popup body as markdown (rendered as HTML by newer TextViewers)
+-- Summary, keypoints and questions are passed through verbatim so their own
+-- inline markdown (bold, italics) renders properly.
 -- @param item table Prereading item with summary, keypoints, questions
--- @return string Multi-section body text
-local function buildPrereadingBody(item)
+-- @return string Markdown body
+local function buildPrereadingMarkdown(item)
 	local sections = {}
 
 	if item.summary and item.summary ~= "" then
-		table.insert(sections, item.summary)
+		table.insert(sections, tostring(item.summary))
 	end
 
 	if item.keypoints and #item.keypoints > 0 then
-		local lines = { _("Key points") }
+		local lines = { "## " .. _("Key points") }
 		for _idx, point in ipairs(item.keypoints) do
-			table.insert(lines, "• " .. tostring(point))
+			table.insert(lines, "- " .. tostring(point))
 		end
 		table.insert(sections, table.concat(lines, "\n"))
 	end
 
 	if item.questions and #item.questions > 0 then
-		local lines = { _("Questions to think about") }
+		local lines = { "## " .. _("Questions to think about") }
 		for i, question in ipairs(item.questions) do
 			table.insert(lines, tostring(i) .. ". " .. tostring(question))
 		end
@@ -116,13 +143,57 @@ local function buildPrereadingBody(item)
 	return table.concat(sections, "\n\n")
 end
 
+--- Build the popup body as plain text, with markdown markers stripped
+-- Fallback for older TextViewers without markdown rendering.
+-- @param item table Prereading item with summary, keypoints, questions
+-- @return string Multi-section plain text body
+local function buildPrereadingBody(item)
+	local sections = {}
+
+	if item.summary and item.summary ~= "" then
+		table.insert(sections, stripMarkdown(item.summary))
+	end
+
+	if item.keypoints and #item.keypoints > 0 then
+		local lines = { _("Key points") }
+		for _idx, point in ipairs(item.keypoints) do
+			table.insert(lines, "• " .. stripMarkdown(point))
+		end
+		table.insert(sections, table.concat(lines, "\n"))
+	end
+
+	if item.questions and #item.questions > 0 then
+		local lines = { _("Questions to think about") }
+		for i, question in ipairs(item.questions) do
+			table.insert(lines, tostring(i) .. ". " .. stripMarkdown(question))
+		end
+		table.insert(sections, table.concat(lines, "\n"))
+	end
+
+	if #sections == 0 then
+		return _("No prereading content available for this chapter.")
+	end
+
+	return table.concat(sections, "\n\n")
+end
+
 --- Show the prereading popup for a matched chapter item
+-- Renders the body as markdown (bold, headings, lists) when this KOReader's
+-- TextViewer supports it, falling back to plain text with markers stripped.
 -- @param item table Prereading item to display
 function UI.showPrereadingPopup(item)
-	UIManager:show(TextViewer:new({
-		title = buildPrereadingTitle(item),
-		text = buildPrereadingBody(item),
-	}))
+	if supportsMarkdown() then
+		UIManager:show(TextViewer:new({
+			title = buildPrereadingTitle(item),
+			text = buildPrereadingMarkdown(item),
+			text_format = "md",
+		}))
+	else
+		UIManager:show(TextViewer:new({
+			title = buildPrereadingTitle(item),
+			text = buildPrereadingBody(item),
+		}))
+	end
 end
 
 --- Show a message when no prereading is cached and we are offline


### PR DESCRIPTION
## Summary

The prereading content from the server contains markdown (e.g. `**Active reading**` in key points), which the popup's TextViewer displayed as literal asterisks in plain text.

**First attempt (1dfa082)** used TextViewer's `text_format = "md"` — but that feature only exists on KOReader master; no released version has it (verified against v2026.03, the latest stable). On real devices the feature detection fell back to plain text with markers stripped: clean, but no bold.

**Final approach (237f536):** a new self-contained `PrereadingViewer` dialog built on `ScrollHtmlWidget`, which has been stable for years (it powers the dictionary popup). The dialog mirrors stable TextViewer's structure — TitleBar with close, scrollable body, Close button, tap-outside/Back-key dismissal, e-ink refresh handling. The HTML is generated in the plugin: `<h2>` section headings, real `<ul>`/`<ol>` lists, and inline `**bold**`/`*italic*`/`` `code` `` converted to `<strong>`/`<em>`/`<code>`, with HTML escaping applied before conversion so content can't inject markup. The stripped-plain-text TextViewer fallback remains for builds where the viewer can't load.

## Testing

- Off-device luajit harness (21/21 pass): bold/italic/code conversion, HTML escaping before conversion (no raw `&`/`<` leaks), heading/list structure, multi-paragraph summaries, viewer-failure fallback to stripped plain text, empty-content placeholder.
- Widget structure and APIs verified against KOReader v2026.03 sources (not master), matching stable TextViewer's sizing math and lifecycle handlers.
- `luac -p` / `luajit -bl` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)