### PR TITLE
Rename prereading to digest and move to the /digest endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Syncs your KOReader highlights to your Crossbill server.
 - Uploads book epub to the Crossbill
 - Uploads reading session data to the Crossbill
 - Works with EPUB files
-- View AI generated chapter summary of the chapter on Koreader
+- View the AI generated digest of the current chapter on KOReader
 
 ## Requirements
 

--- a/copy_to_pocketbook.sh
+++ b/copy_to_pocketbook.sh
@@ -68,9 +68,9 @@ sed -i 's/_("Crossbill")/_("Crossbill Test")/g' "$TMP_TEST_DIR/crossbill-test.ko
 # Change database filename to avoid conflicts with production
 sed -i 's/crossbill_sessions\.sqlite3/test_crossbill_sessions.sqlite3/g' "$TMP_TEST_DIR/crossbill-test.koplugin/test_modules/sessiontracker.lua"
 
-# Modify test_modules/prereading_cache.lua for test version
+# Modify test_modules/digest_cache.lua for test version
 # Change database filename to avoid conflicts with production
-sed -i 's/crossbill_prereading\.sqlite3/test_crossbill_prereading.sqlite3/g' "$TMP_TEST_DIR/crossbill-test.koplugin/test_modules/prereading_cache.lua"
+sed -i 's/crossbill_digests\.sqlite3/test_crossbill_digests.sqlite3/g' "$TMP_TEST_DIR/crossbill-test.koplugin/test_modules/digest_cache.lua"
 
 # Copy test plugin to destination
 cp -R "$TMP_TEST_DIR/crossbill-test.koplugin" "$KOREADER_PLUGINS_PATH/"

--- a/crossbill.koplugin/main.lua
+++ b/crossbill.koplugin/main.lua
@@ -16,8 +16,8 @@ local Network = require("modules/network")
 local Auth = require("modules/auth")
 local ApiClient = require("modules/api_client")
 local SessionTracker = require("modules/sessiontracker")
-local PrereadingCache = require("modules/prereading_cache")
-local PrereadingService = require("modules/prereading_service")
+local DigestCache = require("modules/digest_cache")
+local DigestService = require("modules/digest_service")
 local FileUploader = require("modules/file_uploader")
 local SyncService = require("modules/sync_service")
 local UI = require("modules/ui")
@@ -67,14 +67,14 @@ function CrossbillSync:init()
 	self.session_tracker = SessionTracker:new(self.settings)
 	self.session_tracker:init(DataStorage:getSettingsDir())
 
-	-- Initialize prereading cache (SQLite) and service
-	self.prereading_cache = PrereadingCache:new(self.settings)
-	self.prereading_cache:init(DataStorage:getSettingsDir())
-	self.prereading_service = PrereadingService:new(self.api_client, self.prereading_cache)
+	-- Initialize digest cache (SQLite) and service
+	self.digest_cache = DigestCache:new(self.settings)
+	self.digest_cache:init(DataStorage:getSettingsDir())
+	self.digest_service = DigestService:new(self.api_client, self.digest_cache)
 
 	-- Initialize sync service with all dependencies
 	self.sync_service =
-		SyncService:new(self.api_client, self.file_uploader, self.session_tracker, self.settings, self.prereading_service)
+		SyncService:new(self.api_client, self.file_uploader, self.session_tracker, self.settings, self.digest_service)
 
 	-- Register menu
 	self.ui.menu:registerToMainMenu(self)
@@ -86,8 +86,8 @@ function CrossbillSync:addToMainMenu(menu_items)
 		on_sync = function()
 			self:syncCurrentBook()
 		end,
-		on_show_prereading = function()
-			self:showChapterPrereading()
+		on_show_digest = function()
+			self:showChapterDigest()
 		end,
 		on_configure = function()
 			self:configureServer()
@@ -125,28 +125,28 @@ function CrossbillSync:configureServer()
 	UI.showConfigureServerDialog(self.settings)
 end
 
---- Show a prereading result: popup on success, matching info message otherwise
--- @param item table|nil The matched prereading item
--- @param err_kind string|nil The error kind returned by the prereading service
-function CrossbillSync:_showPrereadingResult(item, err_kind)
+--- Show a digest result: popup on success, matching info message otherwise
+-- @param item table|nil The matched digest item
+-- @param err_kind string|nil The error kind returned by the digest service
+function CrossbillSync:_showDigestResult(item, err_kind)
 	if item then
-		UI.showPrereadingPopup(item)
+		UI.showDigestPopup(item)
 	elseif err_kind == "book_unknown" then
-		UI.showPrereadingBookUnknown()
-	elseif err_kind == "no_prereading_for_book" then
-		UI.showPrereadingEmptyBook()
+		UI.showDigestBookUnknown()
+	elseif err_kind == "no_digest_for_book" then
+		UI.showDigestEmptyBook()
 	elseif err_kind == "chapter_not_matched" then
-		UI.showPrereadingChapterNotMatched()
+		UI.showDigestChapterNotMatched()
 	else
 		-- err_kind == "no_cache" (or any unexpected value)
-		UI.showPrereadingNoCache()
+		UI.showDigestNoCache()
 	end
 end
 
---- Show the current chapter's prereading content
-function CrossbillSync:showChapterPrereading()
+--- Show the current chapter's digest
+function CrossbillSync:showChapterDigest()
 	if not self.ui.document then
-		logger.warn("Crossbill: Cannot show prereading - no document available")
+		logger.warn("Crossbill: Cannot show digest - no document available")
 		return
 	end
 
@@ -154,35 +154,35 @@ function CrossbillSync:showChapterPrereading()
 		return BookMetadata:new(self.ui):extractBookData()
 	end)
 	if not ok or not book_data or not book_data.client_book_id then
-		logger.err("Crossbill: Failed to extract book metadata for prereading")
-		UI.showPrereadingNoCache()
+		logger.err("Crossbill: Failed to extract book metadata for the digest")
+		UI.showDigestNoCache()
 		return
 	end
 
 	local client_book_id = book_data.client_book_id
-	local item, err_kind = self.prereading_service:getForCurrentChapter(self.ui, client_book_id)
+	local item, err_kind = self.digest_service:getForCurrentChapter(self.ui, client_book_id)
 
 	-- Anything other than a missing cache can be shown immediately (no network needed).
 	if err_kind ~= "no_cache" then
-		self:_showPrereadingResult(item, err_kind)
+		self:_showDigestResult(item, err_kind)
 		return
 	end
 
 	-- Nothing cached and the fetch failed: retry once online if WiFi is off.
 	local callback = function()
-		local retry_item, retry_err = self.prereading_service:getForCurrentChapter(self.ui, client_book_id)
-		self:_showPrereadingResult(retry_item, retry_err)
+		local retry_item, retry_err = self.digest_service:getForCurrentChapter(self.ui, client_book_id)
+		self:_showDigestResult(retry_item, retry_err)
 		Network.disableWifiIfNeeded()
 	end
 
 	if not Network.ensureWifiEnabled(callback) then
 		-- WiFi is being enabled; callback will run when online
-		logger.info("Crossbill: Waiting for WiFi to show prereading...")
+		logger.info("Crossbill: Waiting for WiFi to show digest...")
 		return
 	end
 
 	-- Already online but still no cache: the fetch genuinely failed
-	self:_showPrereadingResult(item, err_kind)
+	self:_showDigestResult(item, err_kind)
 	Network.disableWifiIfNeeded()
 end
 
@@ -276,7 +276,7 @@ end
 
 --- Handle the "chapter summary" gesture action
 function CrossbillSync:onCrossbillShowChapterSummary()
-	self:showChapterPrereading()
+	self:showChapterDigest()
 	return true
 end
 
@@ -340,8 +340,8 @@ function CrossbillSync:onExit()
 	if self.session_tracker then
 		self.session_tracker:close()
 	end
-	if self.prereading_cache then
-		self.prereading_cache:close()
+	if self.digest_cache then
+		self.digest_cache:close()
 	end
 	return false
 end

--- a/crossbill.koplugin/main.lua
+++ b/crossbill.koplugin/main.lua
@@ -30,7 +30,7 @@ local CrossbillSync = WidgetContainer:extend({
 
 --- Register gesture-bindable actions with KOReader's Dispatcher
 -- These show up in the gesture manager under "Sync current book with
--- Crossbill" and "Crossbill chapter summary".
+-- Crossbill" and "Crossbill chapter digest".
 function CrossbillSync:onDispatcherRegisterActions()
 	Dispatcher:registerAction("crossbill_sync_current_book", {
 		category = "none",
@@ -38,10 +38,15 @@ function CrossbillSync:onDispatcherRegisterActions()
 		title = _("Sync current book with Crossbill"),
 		reader = true,
 	})
+	-- The action name is the key KOReader stores in a user's gesture and
+	-- profile settings, and Dispatcher silently skips names it no longer
+	-- knows. Renaming this to ..._digest would leave existing bindings
+	-- pointing at nothing, with no error to tell the user why their gesture
+	-- stopped working, so the old name stays. Only the title is user-visible.
 	Dispatcher:registerAction("crossbill_show_chapter_summary", {
 		category = "none",
-		event = "CrossbillShowChapterSummary",
-		title = _("Crossbill chapter summary"),
+		event = "CrossbillShowChapterDigest",
+		title = _("Crossbill chapter digest"),
 		reader = true,
 	})
 end
@@ -274,8 +279,8 @@ function CrossbillSync:onCrossbillSyncCurrentBook()
 	return true
 end
 
---- Handle the "chapter summary" gesture action
-function CrossbillSync:onCrossbillShowChapterSummary()
+--- Handle the "chapter digest" gesture action
+function CrossbillSync:onCrossbillShowChapterDigest()
 	self:showChapterDigest()
 	return true
 end

--- a/crossbill.koplugin/modules/api_client.lua
+++ b/crossbill.koplugin/modules/api_client.lua
@@ -102,35 +102,35 @@ function ApiClient:getBookMetadata(client_book_id)
 	end
 end
 
---- Get prereading content for a book from the server by client_book_id
+--- Get a book's chapter digests from the server by client_book_id
 -- @param client_book_id string The client-side book ID (hash of title|author)
 -- @return number|nil HTTP status code
--- @return table|nil Response data containing an "items" array of chapter prereading
+-- @return table|nil Response data containing an "items" array of chapter digests
 -- @return string|nil Error message
-function ApiClient:getBookPrereading(client_book_id)
+function ApiClient:getBookDigest(client_book_id)
 	local token, auth_err = self.auth:getValidToken()
 	if not token then
 		return nil, nil, auth_err or "Authentication failed"
 	end
 
-	local api_url = self:getApiUrl() .. "/ereader/books/" .. client_book_id .. "/prereading"
-	logger.dbg("Crossbill API: Fetching book prereading from", api_url)
+	local api_url = self:getApiUrl() .. "/ereader/books/" .. client_book_id .. "/digest"
+	logger.dbg("Crossbill API: Fetching book digests from", api_url)
 
 	local code, response_data, err = Network.getJson(api_url, token)
 
 	if not code then
-		logger.err("Crossbill API: Network error fetching prereading:", err)
+		logger.err("Crossbill API: Network error fetching digests:", err)
 		return nil, nil, err or "Network error"
 	end
 
 	if code == 200 and response_data then
-		logger.dbg("Crossbill API: Book prereading fetched successfully")
+		logger.dbg("Crossbill API: Book digests fetched successfully")
 		return code, response_data, nil
 	elseif code == 404 then
-		logger.dbg("Crossbill API: Book not found for prereading (404)")
+		logger.dbg("Crossbill API: Book not found for digests (404)")
 		return code, nil, nil
 	else
-		logger.warn("Crossbill API: Fetch book prereading failed with code:", code)
+		logger.warn("Crossbill API: Fetch book digests failed with code:", code)
 		return code, nil, "Fetch failed: " .. tostring(code)
 	end
 end

--- a/crossbill.koplugin/modules/digest_cache.lua
+++ b/crossbill.koplugin/modules/digest_cache.lua
@@ -1,7 +1,7 @@
 --[[
-Prereading Cache Module for Crossbill Sync
+Digest Cache Module for Crossbill Sync
 
-Caches per-chapter prereading content (summary, key points, questions) in a
+Caches per-chapter digests (summary, key points, questions) in a
 local SQLite3 database so it can be viewed offline. Mirrors the connection,
 WAL and lifecycle patterns used by SessionTracker, but stores its data in its
 own database file.
@@ -11,15 +11,15 @@ local logger = require("logger")
 local SQ3 = require("lua-ljsqlite3/init")
 local JSON = require("json")
 
-local PrereadingCache = {}
-PrereadingCache.__index = PrereadingCache
+local DigestCache = {}
+DigestCache.__index = DigestCache
 
 -- Constants
-local DB_FILENAME = "crossbill_prereading.sqlite3"
+local DB_FILENAME = "crossbill_digests.sqlite3"
 
 -- Database schema
 local SCHEMA = [[
-CREATE TABLE IF NOT EXISTS prereading (
+CREATE TABLE IF NOT EXISTS digest (
     client_book_id TEXT NOT NULL,
     chapter_number INTEGER NOT NULL,
     chapter_name   TEXT NOT NULL,
@@ -32,20 +32,20 @@ CREATE TABLE IF NOT EXISTS prereading (
     PRIMARY KEY (client_book_id, chapter_number)
 );
 
-CREATE INDEX IF NOT EXISTS idx_prereading_book ON prereading(client_book_id);
+CREATE INDEX IF NOT EXISTS idx_digest_book ON digest(client_book_id);
 
-CREATE TABLE IF NOT EXISTS prereading_fetch_meta (
+CREATE TABLE IF NOT EXISTS digest_fetch_meta (
     client_book_id TEXT PRIMARY KEY,
     fetched_at     INTEGER NOT NULL,
     item_count     INTEGER NOT NULL
 );
 ]]
 
---- Create a new PrereadingCache instance
+--- Create a new DigestCache instance
 -- @param settings Settings instance for accessing configuration
--- @return PrereadingCache instance
-function PrereadingCache:new(settings)
-	local instance = setmetatable({}, PrereadingCache)
+-- @return DigestCache instance
+function DigestCache:new(settings)
+	local instance = setmetatable({}, DigestCache)
 	instance.db = nil
 	instance.db_path = nil
 	instance._initialized = false
@@ -56,13 +56,13 @@ end
 --- Initialize the cache with its database
 -- @param data_dir string Path to KOReader settings directory
 -- @return boolean Success status
-function PrereadingCache:init(data_dir)
+function DigestCache:init(data_dir)
 	if self._initialized then
 		return true
 	end
 
 	self.db_path = data_dir .. "/" .. DB_FILENAME
-	logger.dbg("Crossbill PrereadingCache: Initializing database at", self.db_path)
+	logger.dbg("Crossbill DigestCache: Initializing database at", self.db_path)
 
 	local success, err = pcall(function()
 		self.db = SQ3.open(self.db_path)
@@ -73,27 +73,27 @@ function PrereadingCache:init(data_dir)
 	end)
 
 	if not success then
-		logger.err("Crossbill PrereadingCache: Failed to initialize database:", err)
+		logger.err("Crossbill DigestCache: Failed to initialize database:", err)
 		self.db = nil
 		return false
 	end
 
 	self._initialized = true
-	logger.dbg("Crossbill PrereadingCache: Database initialized successfully")
+	logger.dbg("Crossbill DigestCache: Database initialized successfully")
 	return true
 end
 
 --- Close the database connection
-function PrereadingCache:close()
+function DigestCache:close()
 	if self.db then
-		logger.dbg("Crossbill PrereadingCache: Closing database")
+		logger.dbg("Crossbill DigestCache: Closing database")
 		local success, err = pcall(function()
 			-- Checkpoint WAL to ensure all data is written to main file
 			self.db:exec("PRAGMA wal_checkpoint(TRUNCATE);")
 			self.db:close()
 		end)
 		if not success then
-			logger.warn("Crossbill PrereadingCache: Error closing database:", err)
+			logger.warn("Crossbill DigestCache: Error closing database:", err)
 		end
 		self.db = nil
 	end
@@ -152,19 +152,19 @@ local function decodeArray(text)
 	return {}
 end
 
---- Replace all cached prereading for a book with a fresh set of items
+--- Replace a book's cached digests with a fresh set of items
 -- Deletes existing rows and inserts the new ones in a single transaction.
 -- @param client_book_id string The client book ID
--- @param items table Array of prereading items from the API
+-- @param items table Array of digest items from the API
 -- @return boolean Success status
-function PrereadingCache:replaceBook(client_book_id, items)
+function DigestCache:replaceBook(client_book_id, items)
 	if not self._initialized or not self.db then
-		logger.warn("Crossbill PrereadingCache: Cannot replace book - not initialized")
+		logger.warn("Crossbill DigestCache: Cannot replace book - not initialized")
 		return false
 	end
 
 	if not client_book_id then
-		logger.warn("Crossbill PrereadingCache: Cannot replace book - missing client_book_id")
+		logger.warn("Crossbill DigestCache: Cannot replace book - missing client_book_id")
 		return false
 	end
 
@@ -174,13 +174,13 @@ function PrereadingCache:replaceBook(client_book_id, items)
 	local success, err = pcall(function()
 		self.db:exec("BEGIN TRANSACTION;")
 
-		local del_stmt = self.db:prepare("DELETE FROM prereading WHERE client_book_id = ?")
+		local del_stmt = self.db:prepare("DELETE FROM digest WHERE client_book_id = ?")
 		del_stmt:bind(client_book_id)
 		del_stmt:step()
 		del_stmt:close()
 
 		local ins_stmt = self.db:prepare([[
-            INSERT INTO prereading (
+            INSERT INTO digest (
                 client_book_id, chapter_number, chapter_name, parent_chapter_name,
                 summary, keypoints, questions, generated_at, fetched_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -192,7 +192,7 @@ function PrereadingCache:replaceBook(client_book_id, items)
 			if chapter_number == nil then
 				-- The primary key requires an integer chapter_number; skip defensively.
 				logger.warn(
-					"Crossbill PrereadingCache: Skipping item with nil chapter_number for chapter",
+					"Crossbill DigestCache: Skipping item with nil chapter_number for chapter",
 					tostring(item.chapter_name)
 				)
 			else
@@ -217,11 +217,11 @@ function PrereadingCache:replaceBook(client_book_id, items)
 
 		-- Record this fetch so a "fetched and empty" book is distinguishable from
 		-- a "never fetched" one. hasBook checks this meta table, so a book with an
-		-- empty server prereading list still counts as present and does not trigger
+		-- empty server digest list still counts as present and does not trigger
 		-- a re-fetch on every popup open. An empty fetch is refreshed by sync
 		-- (refreshBook), not by popup opens.
 		local meta_stmt = self.db:prepare([[
-            INSERT OR REPLACE INTO prereading_fetch_meta (
+            INSERT OR REPLACE INTO digest_fetch_meta (
                 client_book_id, fetched_at, item_count
             ) VALUES (?, ?, ?)
         ]])
@@ -233,21 +233,21 @@ function PrereadingCache:replaceBook(client_book_id, items)
 	end)
 
 	if not success then
-		logger.err("Crossbill PrereadingCache: Failed to replace book, rolling back:", err)
+		logger.err("Crossbill DigestCache: Failed to replace book, rolling back:", err)
 		pcall(function()
 			self.db:exec("ROLLBACK;")
 		end)
 		return false
 	end
 
-	logger.dbg("Crossbill PrereadingCache: Replaced prereading for book", client_book_id)
+	logger.dbg("Crossbill DigestCache: Replaced digests for book", client_book_id)
 	return true
 end
 
---- Get all cached prereading items for a book, ordered by chapter_number
+--- Get all cached digest items for a book, ordered by chapter_number
 -- @param client_book_id string The client book ID
--- @return table Array of decoded prereading items
-function PrereadingCache:getBook(client_book_id)
+-- @return table Array of decoded digest items
+function DigestCache:getBook(client_book_id)
 	if not self._initialized or not self.db then
 		return {}
 	end
@@ -261,7 +261,7 @@ function PrereadingCache:getBook(client_book_id)
 		local stmt = self.db:prepare([[
             SELECT chapter_number, chapter_name, parent_chapter_name,
                    summary, keypoints, questions, generated_at
-            FROM prereading
+            FROM digest
             WHERE client_book_id = ?
             ORDER BY chapter_number ASC
         ]])
@@ -283,20 +283,20 @@ function PrereadingCache:getBook(client_book_id)
 	end)
 
 	if not success then
-		logger.err("Crossbill PrereadingCache: Error fetching book prereading:", err)
+		logger.err("Crossbill DigestCache: Error fetching book digests:", err)
 	end
 
 	return items
 end
 
---- Check whether a book has ever been fetched (even if it had no prereading)
--- Checks the fetch-meta table rather than counting prereading rows, so a book
--- whose server prereading list was empty still counts as present. This keeps a
+--- Check whether a book has ever been fetched (even if it had no digests)
+-- Checks the fetch-meta table rather than counting digest rows, so a book
+-- whose server digest list was empty still counts as present. This keeps a
 -- popup open from re-attempting a network fetch every time; the empty fetch is
 -- refreshed by sync (refreshBook), not by popup opens.
 -- @param client_book_id string The client book ID
 -- @return boolean True if the book has been fetched at least once
-function PrereadingCache:hasBook(client_book_id)
+function DigestCache:hasBook(client_book_id)
 	if not self._initialized or not self.db then
 		return false
 	end
@@ -307,7 +307,7 @@ function PrereadingCache:hasBook(client_book_id)
 
 	local has = false
 	local success, err = pcall(function()
-		local stmt = self.db:prepare("SELECT 1 FROM prereading_fetch_meta WHERE client_book_id = ? LIMIT 1")
+		local stmt = self.db:prepare("SELECT 1 FROM digest_fetch_meta WHERE client_book_id = ? LIMIT 1")
 		stmt:bind(client_book_id)
 		for _ in stmt:rows() do
 			has = true
@@ -316,11 +316,11 @@ function PrereadingCache:hasBook(client_book_id)
 	end)
 
 	if not success then
-		logger.err("Crossbill PrereadingCache: Error checking book presence:", err)
+		logger.err("Crossbill DigestCache: Error checking book presence:", err)
 		return false
 	end
 
 	return has
 end
 
-return PrereadingCache
+return DigestCache

--- a/crossbill.koplugin/modules/digest_service.lua
+++ b/crossbill.koplugin/modules/digest_service.lua
@@ -1,36 +1,36 @@
 --[[
-Prereading Service Module for Crossbill Sync
+Digest Service Module for Crossbill Sync
 
-UI-free logic that fetches, caches and resolves per-chapter prereading content.
+UI-free logic that fetches, caches and resolves per-chapter digests.
 Given the current reading position it matches the current chapter against the
-cached prereading items using a small, staged matching algorithm.
+cached digest items using a small, staged matching algorithm.
 
 Public API:
-  PrereadingService:new(api_client, prereading_cache)
-  PrereadingService:refreshBook(client_book_id) -> ok, err_kind
-  PrereadingService:getForCurrentChapter(ui, client_book_id) -> item, err_kind
+  DigestService:new(api_client, digest_cache)
+  DigestService:refreshBook(client_book_id) -> ok, err_kind
+  DigestService:getForCurrentChapter(ui, client_book_id) -> item, err_kind
 
 err_kind is one of:
   nil                      matched, item returned
   "no_cache"               nothing cached and the fetch failed/offline
   "book_unknown"           the server returned 404 for this book
-  "no_prereading_for_book" the book is known but has no prereading yet
+  "no_digest_for_book" the book is known but has no digest yet
   "chapter_not_matched"    could not match the current chapter to a cached item
 ]]
 
 local logger = require("logger")
 
-local PrereadingService = {}
-PrereadingService.__index = PrereadingService
+local DigestService = {}
+DigestService.__index = DigestService
 
---- Create a new PrereadingService instance
+--- Create a new DigestService instance
 -- @param api_client ApiClient instance for server communication
--- @param prereading_cache PrereadingCache instance for local caching
--- @return PrereadingService instance
-function PrereadingService:new(api_client, prereading_cache)
-	local instance = setmetatable({}, PrereadingService)
+-- @param digest_cache DigestCache instance for local caching
+-- @return DigestService instance
+function DigestService:new(api_client, digest_cache)
+	local instance = setmetatable({}, DigestService)
 	instance.api_client = api_client
-	instance.cache = prereading_cache
+	instance.cache = digest_cache
 	return instance
 end
 
@@ -137,7 +137,7 @@ local function findParentTitle(toc, index)
 end
 
 --- Stage 1: items whose chapter_name matches the ToC title
--- @param items table Array of cached prereading items
+-- @param items table Array of cached digest items
 -- @param toc_title_norm string|nil Normalized ToC title
 -- @return table Array of matching items (preserves input order)
 local function matchByTitle(items, toc_title_norm)
@@ -207,12 +207,12 @@ end
 
 --- Match the current chapter against the cached items using staged matching
 -- @param ui table The KOReader UI context
--- @param items table Array of cached prereading items
+-- @param items table Array of cached digest items
 -- @return table|nil The matched item, or nil if it could not be matched
 local function matchCurrentChapter(ui, items)
 	local current_index, current_entry = findCurrentTocEntry(ui)
 	if not current_entry then
-		logger.dbg("Crossbill PrereadingService: No current ToC entry could be resolved")
+		logger.dbg("Crossbill DigestService: No current ToC entry could be resolved")
 		return nil
 	end
 
@@ -223,7 +223,7 @@ local function matchCurrentChapter(ui, items)
 	-- Stage 1: match by chapter title.
 	local stage1 = matchByTitle(items, toc_title_norm)
 	if #stage1 == 0 then
-		logger.dbg("Crossbill PrereadingService: No prereading item matches the current chapter title")
+		logger.dbg("Crossbill DigestService: No digest item matches the current chapter title")
 		return nil
 	end
 	if #stage1 == 1 then
@@ -240,25 +240,25 @@ local function matchCurrentChapter(ui, items)
 	return matchByOccurrence(toc, current_index, toc_title_norm, stage1)
 end
 
---- Fetch prereading for a book from the server and replace the cache
+--- Fetch a book's digests from the server and replace the cache
 -- Caller is responsible for WiFi lifecycle.
 -- @param client_book_id string The client book ID
 -- @return boolean ok True if fetched and cached successfully
 -- @return string|nil err_kind "book_unknown" (404) or "fetch_failed", nil on success
-function PrereadingService:refreshBook(client_book_id)
+function DigestService:refreshBook(client_book_id)
 	if not client_book_id then
 		return false, "fetch_failed"
 	end
 
-	local code, data, err = self.api_client:getBookPrereading(client_book_id)
+	local code, data, err = self.api_client:getBookDigest(client_book_id)
 
 	if code == 404 then
-		logger.dbg("Crossbill PrereadingService: Book unknown to server (404)")
+		logger.dbg("Crossbill DigestService: Book unknown to server (404)")
 		return false, "book_unknown"
 	end
 
 	if code ~= 200 or not data then
-		logger.warn("Crossbill PrereadingService: Failed to fetch prereading:", err or tostring(code))
+		logger.warn("Crossbill DigestService: Failed to fetch digests:", err or tostring(code))
 		return false, "fetch_failed"
 	end
 
@@ -268,18 +268,18 @@ function PrereadingService:refreshBook(client_book_id)
 		return false, "fetch_failed"
 	end
 
-	logger.dbg("Crossbill PrereadingService: Cached", #items, "prereading items for", client_book_id)
+	logger.dbg("Crossbill DigestService: Cached", #items, "digest items for", client_book_id)
 	return true, nil
 end
 
---- Resolve the prereading item for the current chapter
+--- Resolve the digest item for the current chapter
 -- Tries the cache first; if the book is absent, fetches it, then matches the
 -- current chapter against the cached items.
 -- @param ui table The KOReader UI context
 -- @param client_book_id string The client book ID
--- @return table|nil item The matched prereading item, or nil
+-- @return table|nil item The matched digest item, or nil
 -- @return string|nil err_kind One of the documented error kinds, nil on success
-function PrereadingService:getForCurrentChapter(ui, client_book_id)
+function DigestService:getForCurrentChapter(ui, client_book_id)
 	if not client_book_id then
 		return nil, "no_cache"
 	end
@@ -297,7 +297,7 @@ function PrereadingService:getForCurrentChapter(ui, client_book_id)
 
 	local items = self.cache:getBook(client_book_id)
 	if not items or #items == 0 then
-		return nil, "no_prereading_for_book"
+		return nil, "no_digest_for_book"
 	end
 
 	local item = matchCurrentChapter(ui, items)
@@ -308,4 +308,4 @@ function PrereadingService:getForCurrentChapter(ui, client_book_id)
 	return item, nil
 end
 
-return PrereadingService
+return DigestService

--- a/crossbill.koplugin/modules/digest_viewer.lua
+++ b/crossbill.koplugin/modules/digest_viewer.lua
@@ -1,7 +1,7 @@
 --[[
-Prereading Viewer Module for Crossbill Sync
+Digest Viewer Module for Crossbill Sync
 
-A self-contained, scrollable dialog that renders prereading content (summary,
+A self-contained, scrollable dialog that renders a chapter digest (summary,
 key points, questions) as rich HTML — so inline markdown (bold, italics, code)
 shows up properly.
 
@@ -64,7 +64,7 @@ local CSS = [[
 	}
 ]]
 
-local PrereadingViewer = InputContainer:extend({
+local DigestViewer = InputContainer:extend({
 	title = nil,
 	html = nil,
 	width = nil,
@@ -76,7 +76,7 @@ local PrereadingViewer = InputContainer:extend({
 	button_padding = Size.padding.default,
 })
 
-function PrereadingViewer:init()
+function DigestViewer:init()
 	local screen_w = Screen:getWidth()
 	local screen_h = Screen:getHeight()
 
@@ -192,33 +192,33 @@ function PrereadingViewer:init()
 	})
 end
 
-function PrereadingViewer:onCloseWidget()
+function DigestViewer:onCloseWidget()
 	UIManager:setDirty(nil, function()
 		return "partial", self.frame.dimen
 	end)
 end
 
-function PrereadingViewer:onShow()
+function DigestViewer:onShow()
 	UIManager:setDirty(self, function()
 		return "partial", self.frame.dimen
 	end)
 	return true
 end
 
-function PrereadingViewer:onTapClose(arg, ges_ev)
+function DigestViewer:onTapClose(arg, ges_ev)
 	if ges_ev.pos:notIntersectWith(self.frame.dimen) then
 		self:onClose()
 	end
 	return true
 end
 
-function PrereadingViewer:onMultiSwipe(arg, ges_ev)
+function DigestViewer:onMultiSwipe(arg, ges_ev)
 	-- Any multiswipe closes, for consistency with other fullscreen widgets.
 	self:onClose()
 	return true
 end
 
-function PrereadingViewer:onClose()
+function DigestViewer:onClose()
 	UIManager:close(self)
 	if self.close_callback then
 		self.close_callback()
@@ -226,4 +226,4 @@ function PrereadingViewer:onClose()
 	return true
 end
 
-return PrereadingViewer
+return DigestViewer

--- a/crossbill.koplugin/modules/highlight_extractor.lua
+++ b/crossbill.koplugin/modules/highlight_extractor.lua
@@ -131,7 +131,7 @@ end
 
 --- Normalize a title for comparison: trim, collapse internal whitespace, lowercase
 -- Non-string input (including JSON null sentinels) normalizes to nil. Mirrors the
--- normalizeTitle semantics used by prereading_service.lua.
+-- normalizeTitle semantics used by digest_service.lua.
 -- @param title string|nil The raw title
 -- @return string|nil The normalized title, or nil for nil/non-string input
 local function normalizeTitle(title)
@@ -178,7 +178,7 @@ local function getNumericPage(document, highlight)
 end
 
 --- Find the flat ToC index containing a page: the last entry whose page <= page
--- Same convention as findCurrentTocEntry in prereading_service.lua.
+-- Same convention as findCurrentTocEntry in digest_service.lua.
 -- @param toc table The flat ToC array
 -- @param page number The highlight's page
 -- @return number|nil The 1-based index into toc, or nil if none

--- a/crossbill.koplugin/modules/sync_service.lua
+++ b/crossbill.koplugin/modules/sync_service.lua
@@ -23,15 +23,15 @@ SyncService.__index = SyncService
 -- @param file_uploader FileUploader instance for file uploads
 -- @param session_tracker SessionTracker instance for reading sessions
 -- @param settings Settings instance for configuration
--- @param prereading_service PrereadingService instance for prereading refresh
+-- @param digest_service DigestService instance for digest refresh
 -- @return SyncService instance
-function SyncService:new(api_client, file_uploader, session_tracker, settings, prereading_service)
+function SyncService:new(api_client, file_uploader, session_tracker, settings, digest_service)
 	local instance = setmetatable({}, SyncService)
 	instance.api_client = api_client
 	instance.file_uploader = file_uploader
 	instance.session_tracker = session_tracker
 	instance.settings = settings
-	instance.prereading_service = prereading_service
+	instance.digest_service = digest_service
 	return instance
 end
 
@@ -90,32 +90,32 @@ function SyncService:syncBook(ui)
 	local session_result = self:_syncReadingSessions(ui, book_data.client_book_id, doc_path)
 	result.sessions_synced = session_result.synced
 
-	-- Refresh cached prereading (best-effort; never fails the sync)
-	self:_refreshPrereading(book_data.client_book_id)
+	-- Refresh cached digests (best-effort; never fails the sync)
+	self:_refreshDigest(book_data.client_book_id)
 
 	return result
 end
 
---- Refresh cached prereading for a book after a successful sync
--- Delegates to the prereading service. Failures are logged only and never
+--- Refresh a book's cached digests after a successful sync
+-- Delegates to the digest service. Failures are logged only and never
 -- propagate to the sync result.
 -- @param client_book_id string The client book ID
-function SyncService:_refreshPrereading(client_book_id)
-	if not self.prereading_service then
+function SyncService:_refreshDigest(client_book_id)
+	if not self.digest_service then
 		return
 	end
 
 	local ok, err = pcall(function()
-		local refreshed, err_kind = self.prereading_service:refreshBook(client_book_id)
+		local refreshed, err_kind = self.digest_service:refreshBook(client_book_id)
 		if not refreshed then
-			logger.warn("Crossbill SyncService: Prereading refresh skipped:", err_kind or "unknown")
+			logger.warn("Crossbill SyncService: Digest refresh skipped:", err_kind or "unknown")
 		else
-			logger.dbg("Crossbill SyncService: Prereading refreshed for", client_book_id)
+			logger.dbg("Crossbill SyncService: Digest refreshed for", client_book_id)
 		end
 	end)
 
 	if not ok then
-		logger.warn("Crossbill SyncService: Error refreshing prereading:", err)
+		logger.warn("Crossbill SyncService: Error refreshing digests:", err)
 	end
 end
 

--- a/crossbill.koplugin/modules/ui.lua
+++ b/crossbill.koplugin/modules/ui.lua
@@ -17,12 +17,12 @@ local _ = require("gettext")
 -- The rich HTML viewer pulls in several KOReader widgets. On an exotic build
 -- where one of those requires is unavailable, we fall back to a plain-text
 -- TextViewer, so load it protectively and treat a failure as "not available".
-local ok_viewer, PrereadingViewer = pcall(function()
-	return require("modules/prereading_viewer")
+local ok_viewer, DigestViewer = pcall(function()
+	return require("modules/digest_viewer")
 end)
 if not ok_viewer then
-	logger.warn("Crossbill: prereading HTML viewer unavailable: " .. tostring(PrereadingViewer))
-	PrereadingViewer = nil
+	logger.warn("Crossbill: digest HTML viewer unavailable: " .. tostring(DigestViewer))
+	DigestViewer = nil
 end
 
 local UI = {}
@@ -84,10 +84,10 @@ function UI.showSessionTrackingToggled(enabled)
 	UI.showMessage(enabled and _("Session tracking enabled") or _("Session tracking disabled"))
 end
 
---- Build the display title for a prereading item
--- @param item table Prereading item with chapter_name and parent_chapter_name
+--- Build the display title for a digest item
+-- @param item table Digest item with chapter_name and parent_chapter_name
 -- @return string Title, prefixed with the parent chapter name when present
-local function buildPrereadingTitle(item)
+local function buildDigestTitle(item)
 	local chapter_name = item.chapter_name or _("Chapter")
 	if item.parent_chapter_name and item.parent_chapter_name ~= "" then
 		return item.parent_chapter_name .. " › " .. chapter_name
@@ -96,7 +96,7 @@ local function buildPrereadingTitle(item)
 end
 
 --- Strip markdown inline markers from a text for plain-text display
--- The server's prereading content contains markdown (e.g. **bold**), which
+-- The server's digest content contains markdown (e.g. **bold**), which
 -- older TextViewers render as literal asterisks. Order matters: bold before
 -- italics so ** is consumed first.
 -- @param text any The raw text (non-strings pass through tostring)
@@ -144,9 +144,9 @@ end
 -- Summary paragraphs (separated by blank lines) become <p> blocks; key points
 -- become a <ul>, questions an <ol>. All content flows through
 -- inlineMarkdownToHtml so bold/italics/code render properly.
--- @param item table Prereading item with summary, keypoints, questions
+-- @param item table Digest item with summary, keypoints, questions
 -- @return string HTML body
-local function buildPrereadingHtml(item)
+local function buildDigestHtml(item)
 	local parts = {}
 
 	if item.summary and item.summary ~= "" then
@@ -181,7 +181,7 @@ local function buildPrereadingHtml(item)
 	end
 
 	if #parts == 0 then
-		return "<p>" .. escapeHtml(_("No prereading content available for this chapter.")) .. "</p>"
+		return "<p>" .. escapeHtml(_("No digest available for this chapter.")) .. "</p>"
 	end
 
 	return table.concat(parts, "\n")
@@ -189,9 +189,9 @@ end
 
 --- Build the popup body as plain text, with markdown markers stripped
 -- Fallback for older TextViewers without markdown rendering.
--- @param item table Prereading item with summary, keypoints, questions
+-- @param item table Digest item with summary, keypoints, questions
 -- @return string Multi-section plain text body
-local function buildPrereadingBody(item)
+local function buildDigestBody(item)
 	local sections = {}
 
 	if item.summary and item.summary ~= "" then
@@ -215,55 +215,55 @@ local function buildPrereadingBody(item)
 	end
 
 	if #sections == 0 then
-		return _("No prereading content available for this chapter.")
+		return _("No digest available for this chapter.")
 	end
 
 	return table.concat(sections, "\n\n")
 end
 
---- Show the prereading popup for a matched chapter item
+--- Show the digest popup for a matched chapter item
 -- Renders the body as rich HTML (bold, headings, lists) via our own
 -- ScrollHtmlWidget-based viewer. If that viewer is unavailable or fails to
 -- construct on some exotic build, falls back to a plain-text TextViewer with
 -- markdown markers stripped.
--- @param item table Prereading item to display
-function UI.showPrereadingPopup(item)
-	if PrereadingViewer then
+-- @param item table Digest item to display
+function UI.showDigestPopup(item)
+	if DigestViewer then
 		local ok, err = pcall(function()
-			UIManager:show(PrereadingViewer:new({
-				title = buildPrereadingTitle(item),
-				html = buildPrereadingHtml(item),
+			UIManager:show(DigestViewer:new({
+				title = buildDigestTitle(item),
+				html = buildDigestHtml(item),
 			}))
 		end)
 		if ok then
 			return
 		end
-		logger.warn("Crossbill: prereading HTML viewer failed, using plain text: " .. tostring(err))
+		logger.warn("Crossbill: digest HTML viewer failed, using plain text: " .. tostring(err))
 	end
 
 	UIManager:show(TextViewer:new({
-		title = buildPrereadingTitle(item),
-		text = buildPrereadingBody(item),
+		title = buildDigestTitle(item),
+		text = buildDigestBody(item),
 	}))
 end
 
---- Show a message when no prereading is cached and we are offline
-function UI.showPrereadingNoCache()
-	UI.showMessage(_("No prereading cached yet. Sync this book while online."), 4)
+--- Show a message when no digest is cached and we are offline
+function UI.showDigestNoCache()
+	UI.showMessage(_("No digest cached yet. Sync this book while online."), 4)
 end
 
 --- Show a message when the book is unknown to the server
-function UI.showPrereadingBookUnknown()
+function UI.showDigestBookUnknown()
 	UI.showMessage(_("Book not found on Crossbill. Sync this book first."), 4)
 end
 
---- Show a message when the book is known but has no prereading generated
-function UI.showPrereadingEmptyBook()
-	UI.showMessage(_("No prereading generated for this book yet. Generate it in the Crossbill web app."), 4)
+--- Show a message when the book is known but has no digest generated
+function UI.showDigestEmptyBook()
+	UI.showMessage(_("No digest generated for this book yet. Generate it in the Crossbill web app."), 4)
 end
 
 --- Show a message when the current chapter could not be matched
-function UI.showPrereadingChapterNotMatched()
+function UI.showDigestChapterNotMatched()
 	UI.showMessage(_("Couldn't match the current chapter to Crossbill's chapter list."), 4)
 end
 
@@ -379,7 +379,7 @@ end
 -- lives under a Settings submenu.
 -- @param handlers table Callback handlers for menu actions
 --   - on_sync: function() Called when sync is triggered
---   - on_show_prereading: function() Called when the chapter summary is requested
+--   - on_show_digest: function() Called when the chapter summary is requested
 --   - on_configure: function() Called when configure is triggered
 --   - is_autosync_enabled: function() Returns autosync state
 --   - on_toggle_autosync: function() Called when autosync is toggled
@@ -398,7 +398,7 @@ function UI.buildMenuItems(handlers)
 			},
 			{
 				text = _("Chapter summary"),
-				callback = handlers.on_show_prereading,
+				callback = handlers.on_show_digest,
 			},
 			{
 				text = _("Settings"),

--- a/crossbill.koplugin/modules/ui.lua
+++ b/crossbill.koplugin/modules/ui.lua
@@ -375,11 +375,11 @@ function UI.showMinSessionDurationDialog(settings, on_save)
 end
 
 --- Build the main menu structure for the plugin
--- Primary actions (sync, chapter summary) are top-level; everything else
+-- Primary actions (sync, chapter digest) are top-level; everything else
 -- lives under a Settings submenu.
 -- @param handlers table Callback handlers for menu actions
 --   - on_sync: function() Called when sync is triggered
---   - on_show_digest: function() Called when the chapter summary is requested
+--   - on_show_digest: function() Called when the chapter digest is requested
 --   - on_configure: function() Called when configure is triggered
 --   - is_autosync_enabled: function() Returns autosync state
 --   - on_toggle_autosync: function() Called when autosync is toggled
@@ -397,7 +397,7 @@ function UI.buildMenuItems(handlers)
 				callback = handlers.on_sync,
 			},
 			{
-				text = _("Chapter summary"),
+				text = _("Chapter digest"),
 				callback = handlers.on_show_digest,
 			},
 			{


### PR DESCRIPTION
Companion to Crossbill-Highlights/crossbill-web#511, which renamed the artifact to **chapter digest** — it is read both before a chapter (to support skimming) and after it as review, so naming it after one of its two uses was wrong.

## Breaking

The API call moves from `/ereader/books/{client_book_id}/prereading` to `/digest`. This version needs a Crossbill server that serves `/digest`; the server keeps a compatibility alias for now, but that alias is being removed, after which older plugin versions stop fetching digests.

## Local cache

`crossbill_prereading.sqlite3` becomes `crossbill_digests.sqlite3`, with tables `digest` and `digest_fetch_meta`. It is a pure cache, refilled on the next sync, so nothing is migrated and no data is lost.

The old file is left on device untouched — it is simply never read again. That leaves a small orphan; say the word if you would rather the plugin delete it on init.

## Also renamed

`prereading_cache.lua`, `prereading_service.lua` and `prereading_viewer.lua` and their classes, plus the three user-visible messages that said "No prereading …" and now say "No digest …". The **Chapter summary** menu label is deliberately unchanged — it never contained the old term, and changing what users see on their device felt like a separate call. The glossary does list "chapter summary" under _Avoid_, so it may be worth a follow-up.

No version bump here: `.github/workflows/release.yml` reads and bumps `_meta.lua` itself, so bumping in the branch would double-count. This wants a **minor** bump at release time.

## Verification

The repo has no test suite, so this was checked by construction:
- every Lua file parses under `luac -p`
- every `require("modules/…")` resolves to a file that exists
- the renamed schema, and each statement the cache issues (insert, select-by-book, fetch-meta upsert, delete-by-book), run against SQLite